### PR TITLE
Fix 'comparePassword' by remove arrow function

### DIFF
--- a/P06-Sign-Up-And-Login/content.md
+++ b/P06-Sign-Up-And-Login/content.md
@@ -166,7 +166,7 @@ UserSchema.pre('save', function(next) {
 });
 
 
-UserSchema.methods.comparePassword = (password, done) => {
+UserSchema.methods.comparePassword = function(password, done) {
   bcrypt.compare(password, this.password, (err, isMatch) => {
     done(err, isMatch);
   });


### PR DESCRIPTION
In ES6 arrow functions (=>) do not bind 'this'