### PR TITLE
Double download of cookie parser

### DIFF
--- a/P06-Sign-Up-And-Login/content.md
+++ b/P06-Sign-Up-And-Login/content.md
@@ -219,7 +219,7 @@ In our case, being logged in will mean that there is an authentic **JWT token - 
 > Install `cookie-parser` and `jsonWebToken`:
 >
 ```bash
-npm install cookie-parser jsonwebtoken -s
+npm install jsonwebtoken -s
 ```
 
 # Use Middleware to handle tokens


### PR DESCRIPTION
cookie parser is downloaded later in the tutorial when it is used, so it is unnecessary to do it here.